### PR TITLE
Add shebang

### DIFF
--- a/ws-switch.sh
+++ b/ws-switch.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 # Set the number of your first/main monitor, find it under `hyrpctl monitors` then find your monitor and it is the ID: value at the top.
 first=1 
 # Set the number of your secondary monitor


### PR DESCRIPTION
shebangs are important to specify the interpreter for a script. 
To my knowledge the default interpreter is sh, which is commonly a symlink to bash, but is actually supposed to be a POSIX compliant shell, usually dash on Debian-based systems. POSIX doesn't have a lot of the stuff bash has, notably the `[[ ]]` in if-statements.
This shebang has /usr/bin/env bash instead of the /bin/bash, because bash might not be located at /bin/bash (e.g. on NixOS systems), but /usr/bin/env is.

Note most Hyprland users are on Arch and NixOS. Arch has /bin/sh linked to bash by default, but many users (especially the ones using Hyprland) are hacky and do install dash manually for performance. NixOS only has /bin/sh and /usr/bin/env.